### PR TITLE
Add tvdb_epoffset and fix defaulttvdbseason="a"

### DIFF
--- a/update_anime_ids.py
+++ b/update_anime_ids.py
@@ -20,6 +20,8 @@ for anime in AniDBIDs.xpath("//anime"):
     except ValueError:
         pass
     tvdb_season = str(anime.xpath("@defaulttvdbseason")[0])
+    if tvdb_season == "a":
+        tvdb_season ='-1'
     try:
         if tvdb_season:
             anime_dict["tvdb_season"] = int(tvdb_season)

--- a/update_anime_ids.py
+++ b/update_anime_ids.py
@@ -25,6 +25,14 @@ for anime in AniDBIDs.xpath("//anime"):
             anime_dict["tvdb_season"] = int(tvdb_season)
     except ValueError:
         pass
+    tvdb_epoffset = str(anime.xpath("@episodeoffset")[0])
+    if tvdb_epoffset == "":
+        tvdb_epoffset ='0'
+    try:
+        if tvdb_epoffset:
+            anime_dict["tvdb_epoffset"] = int(tvdb_epoffset)
+    except ValueError:
+        pass
     imdb_id = str(anime.xpath("@imdbid")[0])
     if imdb_id.startswith("tt"):
         anime_dict["imdb_id"] = imdb_id


### PR DESCRIPTION
## Description

Set value of `defaulttvdbseason="a"` to `tvdb_season = -1`
Add `tvdb_epoffset` and if value is empty then add it with a value of `0`

Something like this should be changed/added to convert.py in pmm to match but i'm not sure about python syntax :
```
            if "tvdb_id" in ids:
                self._anidb_to_tvdb[anidb_id] = int(ids["tvdb_id"])
                if "tvdb_season" in ids and ids["tvdb_season"] == 1 or -1 and "tvdb_epoffset" in ids and ids["tvdb_epoffset"] == 0:
                    self._tvdb_to_anidb[int(ids["tvdb_id"])] = anidb_id
```

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Checklist

- [x ] My code was submitted to the nightly branch of the repository.
